### PR TITLE
Channel name format bug

### DIFF
--- a/app.js
+++ b/app.js
@@ -124,7 +124,6 @@ app.view("launch_modal_submit", async ({ ack, body, context, view }) => {
     // create channel
     const response = await app.client.conversations.create({
       token: context.botToken,
-      name: companyName,
       name: `quote-approvals-${channelName.replace(/\W+/g, "-").toLowerCase()}`,
     });
 

--- a/app.js
+++ b/app.js
@@ -91,7 +91,7 @@ app.action("cancel_ephemeral", async ({ ack, body }) => {
   }
 });
 
-/* NEW CHANNEL ✨ */
+/* NEW CHANNEL CREATION ✨ */
 
 let companyName, justification, discount;
 
@@ -124,7 +124,8 @@ app.view("launch_modal_submit", async ({ ack, body, context, view }) => {
     // create channel
     const response = await app.client.conversations.create({
       token: context.botToken,
-      name: `quote-approvals-${companyName.replace(/\W+/g, "-").toLowerCase()}`,
+      name: companyName,
+      name: `quote-approvals-${channelName.replace(/\W+/g, "-").toLowerCase()}`,
     });
 
     // add users to new channel


### PR DESCRIPTION
- Issue: Channels being created with -'s on the end e.g. `#quote-approvals-google-`
- Fix: `companyName` being passed to `name` instead of `channelName`