### PR TITLE
rely on installation in db

### DIFF
--- a/app.js
+++ b/app.js
@@ -31,10 +31,8 @@ const {
 
 // import database functions
 const {
-  storeTokens,
-  storeLocalInstallation,
-  retrieveTokens,
-  fetchLocalInstallation,
+  storeInstallationInDb,
+  fetchInstallationFromDb,
 } = require("./db/helpers");
 
 // initialize env variables
@@ -61,12 +59,10 @@ const app = new App({
   },
   installationStore: {
     storeInstallation: async (installation) => {
-      await storeTokens(installation);
-      return storeLocalInstallation(installation);
+      return await storeInstallationInDb(installation);
     },
     fetchInstallation: async ({ teamId }) => {
-      const tokens = await retrieveTokens(teamId);
-      const installation = fetchLocalInstallation(tokens, teamId);
+      const installation = await fetchInstallationFromDb(teamId);
       return installation;
     },
   },

--- a/db/installations.json
+++ b/db/installations.json
@@ -1,3 +1,0 @@
-{
-  "installations": []
-}


### PR DESCRIPTION
- Remove reliance on local `installations.json` file
- Point to new table `demo_app_installs` in db (with added `bot_user_id` and `bot_id` columns)
- Retrieve installation object from this table and provide to app
- Add new ENV variables