### PR TITLE
Handles case where private channel already exists

### DIFF
--- a/app.js
+++ b/app.js
@@ -19,6 +19,7 @@ const {
 const {
   app_home,
   channel_exists,
+  private_channel_exists,
   channel_created,
   discount_approved,
   discount_mention,
@@ -681,8 +682,17 @@ app.view(
         }),
       });
     } catch (error) {
-      console.log(`launch_modal_submit error - TEAM_ID = ${body.team.id}`);
-      logger.error(error);
+      if (error.data.error === "name_taken") {
+        // send DM with private channel already exists message
+        await app.client.chat.postMessage({
+          token: context.botToken,
+          channel: body.user.id,
+          blocks: private_channel_exists,
+        });
+      } else {
+        console.log(`launch_modal_submit error - TEAM_ID = ${body.team.id}`);
+        logger.error(error);
+      }
     }
   }
 );

--- a/blocks/messages.js
+++ b/blocks/messages.js
@@ -438,6 +438,15 @@ module.exports = {
       },
     },
   ],
+  private_channel_exists: [
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: `Oops! :open_mouth: It looks like a discount approval has *already been requested* for this company. It's likely a private channel and called something like :lock:*quote-approvals-COMPANY*`,
+      },
+    },
+  ],
   discount_approved: (companyName, url) => [
     {
       type: "section",


### PR DESCRIPTION
**Before**
If a user was trying to start the discount approval process for a channel that already exists, but the channel was private, the app would just fail silently. Public channels already existing were handled with an error message DM'd to the user, but private channels were not handled in this way.

**After**
Now, if a user tries to start a discount approval process for a private channel, they will receive an DM from the app explaining that the channel already exists.